### PR TITLE
Fix year validation in child table script

### DIFF
--- a/rada/public/js/reference_part.js
+++ b/rada/public/js/reference_part.js
@@ -1,9 +1,12 @@
-frappe.ui.form.on('Applicable Units', {
-    to_year: function(frm, cdt, cdn) {
-        const row = locals[cdt][cdn];
-        if (row.to_year && row.from_year && row.to_year < row.from_year) {
-            frappe.msgprint(__('To Year cannot be earlier than From Year'));
-            frappe.model.set_value(cdt, cdn, 'to_year', row.from_year);
-        }
+function validate_years(frm, cdt, cdn) {
+    const row = locals[cdt][cdn];
+    if (row.to_year && row.from_year && row.to_year < row.from_year) {
+        frappe.msgprint(__('To Year cannot be earlier than From Year'));
+        frappe.model.set_value(cdt, cdn, 'to_year', row.from_year);
     }
+}
+
+frappe.ui.form.on('Applicable Units', {
+    to_year: validate_years,
+    from_year: validate_years
 });


### PR DESCRIPTION
## Summary
- ensure "Applicable Units" child table validates year ranges when either year field changes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'frappe')*

------
https://chatgpt.com/codex/tasks/task_e_686f934c3ab08332bf324e1241657c9f